### PR TITLE
Email auto link fix

### DIFF
--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -141,6 +141,10 @@ module RailsAutolink
               else
                 display_text = (block_given?) ? yield(text) : text
 
+                if display_text.is_a?(Hash)
+                  display_text = display_text[:title]
+                end
+
                 unless options[:sanitize] == false
                   text         = sanitize(text)
                   display_text = sanitize(display_text) unless text == display_text

--- a/lib/rails_autolink/helpers.rb
+++ b/lib/rails_autolink/helpers.rb
@@ -142,7 +142,7 @@ module RailsAutolink
                 display_text = (block_given?) ? yield(text) : text
 
                 if display_text.is_a?(Hash)
-                  display_text = display_text[:title]
+                  display_text = display_text[:text]
                 end
 
                 unless options[:sanitize] == false

--- a/rails_autolink.gemspec
+++ b/rails_autolink.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'friendlyfashion-rails_autolink'
-  s.version = '1.0.12'
+  s.version = '1.0.13'
   s.authors = ["Laurynas Butkus", "Tomas Didziokas", "Justas Janauskas", "Edvinas Bartkus", "Andrius Janauskas"]
   s.email   = ["laurynas.butkus@gmail.com", "tomas.did@gmail.com", "jjanauskas@gmail.com", "edvinas.bartkus@gmail.com", "andrius.janauskas@gmail.com"]
   s.summary = 'This is an extraction of the `auto_link` method from rails. The `auto_link` method was removed from Rails in version Rails 3.1. This gem is meant to bridge the gap for people migrating.'

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -61,10 +61,10 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
   def test_auto_link_with_block_with_returns_hash_with_email
     url = 'jeffry@google.com'
     result = auto_link(url) do |it|
-      { text: "jeffry@google.com", href: "http://www.google.com" }
+      { text: "jeffry email" }
     end
 
-    assert_equal "<a href=\"mailto:jeffry@google.com\">jeffry@google.com</a>", result
+    assert_equal "<a href=\"mailto:jeffry@google.com\">jeffry email</a>", result
   end
 
   def test_auto_link_with_block_which_returns_hash_with_html_options

--- a/test/test_rails_autolink.rb
+++ b/test/test_rails_autolink.rb
@@ -58,6 +58,15 @@ class TestRailsAutolink < MiniTest::Unit::TestCase
     assert_equal '<a href="http://www.facebook.com">www.facebook.com</a>', result
   end
 
+  def test_auto_link_with_block_with_returns_hash_with_email
+    url = 'jeffry@google.com'
+    result = auto_link(url) do |it|
+      { text: "jeffry@google.com", href: "http://www.google.com" }
+    end
+
+    assert_equal "<a href=\"mailto:jeffry@google.com\">jeffry@google.com</a>", result
+  end
+
   def test_auto_link_with_block_which_returns_hash_with_html_options
     url = 'http://www.google.com/'
     result = auto_link(url) do |it|


### PR DESCRIPTION
FIxed bug when block returned hash and was processed by email auto link method
